### PR TITLE
Add branch to Circle CI cache key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,10 +7,10 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: node-cache-v2{{ checksum "package.json" }}
+          key: node-cache-v2-{{ .Branch }}-{{ checksum "package.json" }}
       - run: npm install
       - save_cache:
-          key: node-cache-v2{{ checksum "package.json" }}
+          key: node-cache-v2-{{ .Branch }}-{{ checksum "package.json" }}
           paths:
             - ./node_modules
       - run:
@@ -24,7 +24,7 @@ jobs:
       - attach_workspace:
           at: .
       - restore_cache:
-          key: node-cache-v2{{ checksum "package.json" }}
+          key: node-cache-v2-{{ .Branch }}-{{ checksum "package.json" }}
       - run: git clone git@github.com:Rise-Vision/private-keys.git
       - run:
           name: Deploy


### PR DESCRIPTION
Build started failing because it cannot find the eslint command when running the deployment script. I think it is related to Circle CI's cache. I hope this will fix it.

Based on https://circleci.com/docs/2.0/caching/#clearing-cache