### PR TITLE
Fix to machine id not being generated when running on development

### DIFF
--- a/src/messaging/messaging-service-client.js
+++ b/src/messaging/messaging-service-client.js
@@ -1,6 +1,7 @@
 /* eslint-disable max-statements */
 const Primus = require('./primus');
 const logger = require('../logging/logger');
+const systemInfo = require('../logging/system-info');
 
 const messageHandlers = {};
 
@@ -44,12 +45,13 @@ function connect(displayId, machineId) {
 }
 
 function readDisplayAndMachineIds() {
-  return new Promise((resolve) => chrome.storage.local.get(resolve));
+  return Promise.all([systemInfo.getDisplayId(), systemInfo.getMachineId()])
 }
 
 function init() {
-  return readDisplayAndMachineIds().then((items) => {
-    return connect(items.displayId, items.machineId);
+  return readDisplayAndMachineIds().then((values) => {
+    const [displayId, machineId] = values;
+    return connect(displayId, machineId);
   });
 }
 


### PR DESCRIPTION
Introduced after [adding the code to prevent logs from development](https://github.com/Rise-Vision/chrome-os-player/pull/46/commits/ddc81f9a0330a244d5fd9834c15030ea275b986a). It affects the connection to messaging service when running on development.