### PR TITLE
Restore required_platform_version but adds the always update flag to enable app updates

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -53,5 +53,9 @@
       ]
     },
     "offline_enabled": true,
-    "kiosk_enabled": true
+    "kiosk_enabled": true,
+    "kiosk": {
+      "always_update": true,
+      "required_platform_version": "10032.86.0"
+    }
   }


### PR DESCRIPTION
I confirmed the `required_platform_version` was preventing the updates on uptime machines. This is how this feature works according to the [documentation](https://support.google.com/chrome/a/answer/3316168#expectbehaviour):

> Scenario: The required_platform_version value is lower than the device’s current platform version. Result: The app is installed but the device OS will not get updated unless the required_platform_version value is updated to a version higher than the current device OS version.
Note: The first time an app is pushed from the Chrome Web Store, the required_platform_version value is verified, but not compared to the device’s current platform version.

However there is this `always_update` flag that was created to overcome this limitation. This flag is not well documented but I found this bug report that describes how it works: https://bugs.chromium.org/p/chromium/issues/detail?id=673527 

I hope we'll be able to have app updates while still controlling the platform version with this PR. 