### PR TITLE
Remove keep awake flag handling from registration window

### DIFF
--- a/src/window-manager.js
+++ b/src/window-manager.js
@@ -5,10 +5,7 @@ function startRegistration() {
     outerBounds: getDefaultScreenBounds()
   };
 
-  chrome.power.requestKeepAwake('display');
-  chrome.app.window.create('registration.html', options, (playerWindow) => {
-    playerWindow.onClosed.addListener(() => chrome.power.releaseKeepAwake());
-  });
+  chrome.app.window.create('registration.html', options);
 }
 
 function launchViewer(displayId) {

--- a/test/unit/window-manager.js
+++ b/test/unit/window-manager.js
@@ -36,22 +36,6 @@ describe('Window Manager', () => {
     sinon.assert.calledWith(chrome.app.window.create, 'registration.html', expectedWindowOptions);
   });
 
-  it('should request keep awake when registration window is launched', () => {
-    windowManager.startRegistration();
-
-    sinon.assert.calledWith(chrome.power.requestKeepAwake, 'display');
-  });
-
-  it('should release keep awake when registration window is closed', () => {
-    const playerWindow = {onClosed: {addListener() {}}};
-    sandbox.stub(playerWindow.onClosed, 'addListener').yields([]);
-    chrome.app.window.create.yields(playerWindow);
-
-    windowManager.startRegistration();
-
-    sinon.assert.calledOnce(chrome.power.releaseKeepAwake);
-  });
-
   it('should launch viewer', () => {
     const expectedWindowOptions = {id: 'viewer', state: 'fullscreen', outerBounds: expectedDefaultOuterBounds};
 


### PR DESCRIPTION
I think there's a race condition with setting/releasing the flag when the registration window is closed after viewer window is launched. 

I think the keep awake is only a requirement for viewer as registration requires user interaction so it is more likely that the display is not going to be idle enough to be turned off. Removing it will fix the race condition and keep awake should work fine for viewer.