### PR TITLE
Add delay in set keep alive to fix HTTP server when running on Chrome OS

### DIFF
--- a/src/storage/file-server.js
+++ b/src/storage/file-server.js
@@ -126,7 +126,8 @@ function sendBuffer({socketId, buffer, keepAlive}) {
       if (chrome.runtime.lastError || !(socketInfo && socketInfo.connected)) {
         return resolve(destroySocketById(socketId));
       }
-      chrome.sockets.tcp.setKeepAlive(socketId, keepAlive, () => {
+      const delayInSeconds = 1;
+      chrome.sockets.tcp.setKeepAlive(socketId, keepAlive, delayInSeconds, () => {
         if (chrome.runtime.lastError) {
           return resolve(destroySocketById(socketId));
         }


### PR DESCRIPTION
Tested on my Asus Chromebox and on Mac OS and Ubuntu