### PR TITLE
Fix viewer messaging to work with multiple callers

### DIFF
--- a/src/messaging/viewer-messaging.js
+++ b/src/messaging/viewer-messaging.js
@@ -1,4 +1,15 @@
-const dataHandlerRegisteredObserver = {resolve: () => {}, messageReceived: false};
+const dataHandlerRegisteredObserver = {
+  init() {
+    this.messageReceived = false;
+    this.resolvers = [];
+  },
+  resolve() {
+    while (this.resolvers.length > 0) {
+      const fn = this.resolvers.pop();
+      fn();
+    }
+  }
+};
 const messageHandlers = {};
 let messageSender = null;
 
@@ -12,6 +23,8 @@ function createMessageSender(webview) {
 
 function init(webview) {
   messageSender = createMessageSender(webview);
+
+  dataHandlerRegisteredObserver.init();
 
   on('data-handler-registered', () => {
     dataHandlerRegisteredObserver.messageReceived = true;
@@ -61,9 +74,9 @@ function handleMessage(data) {
 
 function viewerCanReceiveContent() {
   return new Promise(resolve => {
-    dataHandlerRegisteredObserver.resolve = resolve;
+    dataHandlerRegisteredObserver.resolvers.push(resolve);
     if (dataHandlerRegisteredObserver.messageReceived) {
-      resolve();
+      dataHandlerRegisteredObserver.resolve();
     }
   });
 }

--- a/test/unit/messaging/viewer-messaging.js
+++ b/test/unit/messaging/viewer-messaging.js
@@ -38,6 +38,15 @@ describe('Viewer Messaging', () => {
     return viewerMessaging.viewerCanReceiveContent();
   });
 
+  it('should indicate viewer can receive content for multiple callers', () => {
+    const data = {from: 'viewer', message: 'data-handler-registered'};
+    const promises = [viewerMessaging.viewerCanReceiveContent(), viewerMessaging.viewerCanReceiveContent()];
+
+    onMessageEvent({data, preventDefault() {}});
+
+    return Promise.all(promises);
+  });
+
   it('should respond to client list request message', () => {
     sandbox.stub(webview.contentWindow, 'postMessage');
 


### PR DESCRIPTION
Content wasn't showing up sometimes because `viewerMessaging.viewerCanReceiveContent()` was designed for a single caller and now it this method is used when sending content to viewer and when initializing licensing.