### PR TITLE
Show the invalid display screen when data indicates that display id is no longer valid

### DIFF
--- a/src/content-loader.js
+++ b/src/content-loader.js
@@ -1,4 +1,5 @@
 const gcsClient = require('./gcs-client');
+const logger = require('./logging/logger');
 
 function readDisplayId() {
   return new Promise((resolve) => chrome.storage.local.get(items => resolve(items.displayId)));
@@ -11,6 +12,27 @@ function fetchContent() {
     return gcsClient.fetchJson(bucketName, filePath);
   })
   .then((contentData) => {
+    if (!contentData || Object.entries(contentData).length === 0) {
+      logger.error('empty content data');
+      return null;
+    }
+    return contentData;
+  })
+  .then(contentData => {
+    chrome.storage.local.set({content: contentData});
+    return contentData;
+  });
+}
+
+function loadData() {
+  return new Promise((resolve) => {
+    chrome.storage.local.get(items => resolve(items.content));
+  })
+  .then((savedContent) => savedContent || fetchContent());
+}
+
+function loadContent() {
+  return loadData().then((contentData) => {
     const regex = new RegExp('http(?:s?)://s3.amazonaws.com/widget-(image|video)', 'g');
     const rewriteUrl = (match, widgetName) => `http://widgets.risevision.com/widget-${widgetName}`; // eslint-disable-line func-style
     contentData.content.presentations.forEach((presentation) => presentation.layout = presentation.layout.replace(regex, rewriteUrl));
@@ -19,5 +41,6 @@ function fetchContent() {
 }
 
 module.exports = {
-  fetchContent
+  fetchContent,
+  loadContent
 }

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -29,11 +29,7 @@ function setUpMessaging() {
 }
 
 function fetchContent() {
-  Promise.all([contentLoader.fetchContent(), viewerMessaging.viewerCanReceiveContent()]).then((values) => {
-    if (!values || values === {}) {
-      logger.error('empty content response');
-      return;
-    }
+  Promise.all([contentLoader.loadContent(), viewerMessaging.viewerCanReceiveContent()]).then((values) => {
     const [contentData] = values;
     logger.log('sending content to viewer', contentData);
     viewerMessaging.send({from: 'player', topic: 'content-update', newContent: contentData});

--- a/test/unit/content-loader.js
+++ b/test/unit/content-loader.js
@@ -3,6 +3,7 @@ const assert = require('assert');
 const sinon = require('sinon');
 const chrome = require('sinon-chrome/apps');
 const gcsClient = require('../../src/gcs-client');
+const logger = require('../../src/logging/logger');
 
 const contentLoader = require('../../src/content-loader');
 
@@ -14,11 +15,24 @@ describe('Content Loader', () => {
 
   afterEach(() => sandbox.restore());
 
+  beforeEach(() => sandbox.stub(logger, 'error'));
+
+  it('should load local content', () => {
+    const localData = {displayId: 'displayId', content: {content: {presentations: []}}};
+    chrome.storage.local.get.yields(localData);
+    sandbox.stub(gcsClient, 'fetchJson').resolves({content: {presentations: []}});
+
+    return contentLoader.loadContent().then((data) => {
+      assert.equal(data, localData.content);
+      sinon.assert.notCalled(gcsClient.fetchJson);
+    });
+  });
+
   it('should fetch content from GCS', () => {
     chrome.storage.local.get.yields({displayId: 'displayId'});
     sandbox.stub(gcsClient, 'fetchJson').resolves({content: {presentations: []}});
 
-    return contentLoader.fetchContent().then(() => {
+    return contentLoader.loadContent().then(() => {
       sinon.assert.calledWith(gcsClient.fetchJson, 'risevision-display-notifications', 'displayId/content.json');
     });
   });
@@ -48,11 +62,21 @@ describe('Content Loader', () => {
     };
     sandbox.stub(gcsClient, 'fetchJson').resolves(contentData);
 
-    return contentLoader.fetchContent().then((data) => {
+    return contentLoader.loadContent().then((data) => {
       const layout = data.content.presentations[0].layout;
       assert.equal(layout.indexOf('http://s3.amazonaws.com/widget-image-test/stage-0/0.1.1/dist/widget.html'), -1);
       assert.equal(layout.indexOf('http://s3.amazonaws.com/widget-video-rv/1.1.0/dist/widget.html'), -1);
       assert.equal(layout.indexOf('http://s3.amazonaws.com/widget-text/1.0.0/dist/widget.html') > 0, true);
+    });
+  });
+
+  it('should return null and log error when content from GCS is empty', () => {
+    chrome.storage.local.get.yields({displayId: 'displayId'});
+    sandbox.stub(gcsClient, 'fetchJson').resolves({});
+
+    return contentLoader.fetchContent().then((data) => {
+      sinon.assert.calledWith(logger.error, 'empty content data');
+      assert.equal(data, null);
     });
   });
 


### PR DESCRIPTION
- Moved fetch content to registration/countdown window
- Store content in local storage to avoid refetching it on viewer/player window
- Show display id screen with invalid display id message if content indicates that the display id is no longer valid (empty object is returned)