### PR TITLE
Enable legacy id input

### DIFF
--- a/src/display-registration/display-id.html
+++ b/src/display-registration/display-id.html
@@ -16,7 +16,7 @@
     <div class="form-group">
       <form id="displayIdForm">
         <label class="secondary-label" for="displayIdInput">Display ID</label>
-        <input id="displayIdInput" autofocus type="text" class="form-control id-form" maxlength="12" autocorrect="off" autocapitalize="off"
+        <input id="displayIdInput" autofocus type="text" class="form-control id-form" autocorrect="off" autocapitalize="off"
           spellcheck="false" placeholder="000000000000" />
       </form>
       <div class="text-right">


### PR DESCRIPTION
  - Removed maxlength attribute from display id input to support legacy ids