### PR TITLE
Catch MS connection error on init

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -38,7 +38,8 @@ function setUpMessaging() {
     });
   });
 
-  return messaging.init();
+  return messaging.init()
+  .catch(() => logger.log('MS connection failed on init'));
 }
 
 function setupLogEvents(webview) {


### PR DESCRIPTION
  - Avoid logging the same error twice and allow other modules to be initialized