### PR TITLE
Add sched / pres change logging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   "test":
     docker: &DOCKERIMAGE
-      - image: jenkinsrise/cci-v2-launcher-electron:0.0.6
+      - image: jenkinsrise/cci-latest-node-with-gcloud:0.0.1
     steps:
       - checkout
       - restore_cache:

--- a/src/content-comparison.js
+++ b/src/content-comparison.js
@@ -1,0 +1,64 @@
+module.exports = {
+  compareContentData(newData) {
+    if (!validateData(newData)) {return Promise.reject(Error('invalid data'));}
+
+    const newPresDates = getPresDatesFromContent(newData);
+
+    const newSchedDate = {
+      "id": newData.content.schedule.id,
+      "changeDate": newData.content.schedule.changeDate
+    };
+
+    return new Promise(res=>{
+      chrome.storage.local.get(items => {
+        chrome.storage.local.set({
+          presDates: newPresDates,
+          schedDate: newSchedDate
+        });
+
+        res({
+          aPresentationHasChanged: presDatesChanged(items.presDates, newPresDates),
+          theScheduleHasChanged: schedChanged(items.schedDate, newSchedDate)
+        });
+      });
+    });
+  },
+  presDatesChanged,
+  getPresDatesFromContent,
+  schedChanged
+};
+
+function validateData(newData) {
+  if (!newData) {return false}
+  if (!newData.content) {return false}
+  if (!newData.content.schedule) {return false}
+  if (!newData.content.presentations) {return false}
+
+  return true;
+}
+
+function getPresDatesFromContent({content}) {
+  return content.presentations.map(({id, changeDate})=>({id, changeDate}))
+  .reduce((presDates, idAndDate)=>{
+    return {
+      ...presDates,
+      [idAndDate.id]: idAndDate.changeDate
+    };
+  }, {});
+}
+
+function presDatesChanged(oldDates, newDates) {
+  if (!oldDates || !newDates) {return}
+
+  return Object.keys(newDates)
+  .some(presId=>oldDates[presId] && oldDates[presId] !== newDates[presId]);
+}
+
+function schedChanged(oldSched, newSched) {
+  if (!oldSched || !newSched) {return}
+
+  const differentSched = oldSched.id !== newSched.id;
+  const modifiedSched = oldSched.changeDate !== newSched.changeDate;
+
+  return differentSched || modifiedSched;
+}

--- a/src/content-loader.js
+++ b/src/content-loader.js
@@ -1,4 +1,5 @@
 const gcsClient = require('./gcs-client');
+const updateFrequencyLogger = require('./update-frequency-logger');
 const logger = require('./logging/logger');
 
 function readDisplayId() {
@@ -19,6 +20,8 @@ function fetchContent() {
     return contentData;
   })
   .then(contentData => {
+    updateFrequencyLogger.logContentChanges(contentData);
+
     chrome.storage.local.set({content: contentData});
     return contentData;
   });

--- a/src/update-frequency-logger.js
+++ b/src/update-frequency-logger.js
@@ -1,0 +1,17 @@
+const contentComparison = require('./content-comparison');
+const logger = require('./logging/logger');
+
+module.exports = {
+  logContentChanges(contentData) {
+    contentComparison.compareContentData(contentData)
+    .then(result=>{
+      if (!result) {return}
+
+      const {aPresentationHasChanged, theScheduleHasChanged} = result;
+
+      if (aPresentationHasChanged) {logger.log('presentation updated');}
+      if (theScheduleHasChanged) {logger.log('schedule updated');}
+    })
+    .catch(err=>logger.error('Error comparing content.json data', err));
+  }
+};

--- a/test/unit/content-comparison.js
+++ b/test/unit/content-comparison.js
@@ -1,0 +1,247 @@
+/* eslint-disable no-magic-numbers */
+const assert = require('assert');
+const sinon = require('sinon');
+const chrome = require('sinon-chrome/apps');
+
+const contentComparison = require('../../src/content-comparison');
+
+const sandbox = sinon.createSandbox();
+
+describe('Content Comparison', () => {
+
+  after(() => chrome.flush());
+
+  afterEach(() => sandbox.restore());
+
+  it('should retrieve presentation dates from the content.json format', () => {
+    const contentJsonData = {
+      content: {
+        irrelevantData: "xxx",
+        presentations: [
+          {
+            "id": "pres-test-id-1",
+            "changeDate": "test-change-date-1"
+          },
+          {
+            "id": "pres-test-id-2",
+            "changeDate": "test-change-date-2"
+          }
+        ]
+      }
+    };
+
+    const expectedTransformation = {
+      "pres-test-id-1": "test-change-date-1",
+      "pres-test-id-2": "test-change-date-2"
+    };
+
+    const testResult = contentComparison.getPresDatesFromContent(contentJsonData);
+    assert.deepEqual(testResult, expectedTransformation);
+  });
+
+  it('should recognize unchanged presentation change dates', () => {
+    const newData = {
+      content: {
+        presentations: [
+          {
+            "id": "pres-id-1",
+            "changeDate": "date-1"
+          },
+          {
+            "id": "pres-id-2",
+            "changeDate": "date-2"
+          }
+        ],
+        schedule: {}
+      }
+    };
+
+    const localData = {
+      presDates: {
+        "pres-id-1": "date-1",
+        "pres-id-2": "date-2"
+      }
+    };
+
+    chrome.storage.local.get.yields(localData);
+
+    return contentComparison.compareContentData(newData)
+    .then(result=>{
+      assert(result.aPresentationHasChanged === false);
+    });
+  });
+
+  it('should recognize changed presentation change dates', () => {
+    const newData = {
+      content: {
+        presentations: [
+          {
+            "id": "pres-id-1",
+            "changeDate": "date-1-new"
+          },
+          {
+            "id": "pres-id-2",
+            "changeDate": "date-2"
+          }
+        ],
+        schedule: {}
+      }
+    };
+
+    const localData = {
+      presDates: {
+        "pres-id-1": "date-1",
+        "pres-id-2": "date-2"
+      }
+    };
+
+    chrome.storage.local.get.yields(localData);
+
+    return contentComparison.compareContentData(newData)
+    .then(result=>{
+      assert(result.aPresentationHasChanged === true);
+    });
+  });
+
+  it('should not indicate change if a presentation has been removed', () => {
+    const newData = {
+      content: {
+        presentations: [
+          {
+            "id": "pres-id-2",
+            "changeDate": "date-2"
+          }
+        ],
+        schedule: {}
+      }
+    };
+
+    const localData = {
+      presDates: {
+        "pres-id-1": "date-1",
+        "pres-id-2": "date-2"
+      }
+    };
+
+    chrome.storage.local.get.yields(localData);
+
+    return contentComparison.compareContentData(newData)
+    .then(result=>{
+      assert(result.aPresentationHasChanged === false);
+    });
+  });
+
+  it('should recognize unchanged schedule change date', () => {
+    const newData = {
+      content: {
+        presentations: [],
+        schedule: {
+          "id": "sched-id",
+          "changeDate": "sched-date"
+        }
+      }
+    };
+
+    const localData = {
+      schedDate: {
+        "id": "sched-id",
+        "changeDate": "sched-date"
+      }
+    };
+
+    chrome.storage.local.get.yields(localData);
+
+    return contentComparison.compareContentData(newData)
+    .then(result=>{
+      assert(result.theScheduleHasChanged === false);
+    });
+  });
+
+  it('should recognize changed schedule change date', () => {
+    const newData = {
+      content: {
+        presentations: [],
+        schedule: {
+          "id": "sched-id",
+          "changeDate": "sched-date-new"
+        }
+      }
+    };
+
+    const localData = {
+      schedDate: {
+        "id": "sched-id",
+        "changeDate": "sched-date"
+      }
+    };
+
+    chrome.storage.local.get.yields(localData);
+
+    return contentComparison.compareContentData(newData)
+    .then(result=>{
+      assert(result.theScheduleHasChanged === true);
+    });
+  });
+
+  it('should recognize changed schedule id', () => {
+    const newData = {
+      content: {
+        presentations: [],
+        schedule: {
+          "id": "sched-id-new",
+          "changeDate": "sched-date"
+        }
+      }
+    };
+
+    const localData = {
+      schedDate: {
+        "id": "sched-id",
+        "changeDate": "sched-date"
+      }
+    };
+
+    chrome.storage.local.get.yields(localData);
+
+    return contentComparison.compareContentData(newData)
+    .then(result=>{
+      assert(result.theScheduleHasChanged === true);
+    });
+  });
+
+  describe("Content.json data object validation", ()=>{
+    it('emptiness', () => {
+      assert.rejects(contentComparison.compareContentData())
+    });
+
+    it('missing content object', () => {
+      assert.rejects(contentComparison.compareContentData({}))
+    });
+
+    it('missing schedule object', () => {
+      assert.rejects(contentComparison.compareContentData({
+        content: {
+          presentations: []
+        }
+      }))
+    });
+
+    it('missing presentation object', () => {
+      assert.rejects(contentComparison.compareContentData({
+        content: {
+          schedule: {}
+        }
+      }))
+    });
+
+    it('passing', () => {
+      assert.doesNotReject(contentComparison.compareContentData({
+        content: {
+          schedule: {},
+          presentations: []
+        }
+      }))
+    });
+  });
+
+});


### PR DESCRIPTION
https://trello.com/c/IMMMbYBm/4558-3-chros-log-an-event-when-my-presentation-or-schedule-has-been-updated

Schedule and presentations are compared to determine if there are any changes to log. Comparison uses `changeDate` rather than a hash.