### PR TITLE
Fix restart on old Chrome OS versions

### DIFF
--- a/src/reboot-scheduler.js
+++ b/src/reboot-scheduler.js
@@ -29,7 +29,17 @@ function scheduleRebootFromViewerContents(content, nowDate = Date.now()) {
   const seconds = Math.floor((rebootDate - nowDate) / MILLISECONDS);
 
   logger.log(`scheduling reboot for ${rebootDate} in ${seconds} seconds from now`);
-  chrome.runtime.restartAfterDelay(seconds);
+  if (typeof chrome.runtime.restartAfterDelay === 'function') {
+    chrome.runtime.restartAfterDelay(seconds);
+  } else {
+    chrome.alarms.create('restart', {when: rebootDate});
+    chrome.alarms.onAlarm.addListener(alarm => {
+      if (alarm.name === 'restart') {
+        logger.log('restarting after alarm');
+        chrome.runtime.restart();
+      }
+    });
+  }
 }
 
 function parseRebootDate(restartHHMM, nowDate) {

--- a/test/unit/reboot-scheduler.js
+++ b/test/unit/reboot-scheduler.js
@@ -97,4 +97,22 @@ describe('Reboot Scheduler', () => {
     sinon.assert.called(chrome.runtime.reload);
   });
 
+  it('should schedule alarm if restartAfterDelay is not available', () => {
+    sandbox.stub(envVars, 'isKioskSession').returns(true);
+    const originalRestartAfterDelay = chrome.runtime.restartAfterDelay;
+    Reflect.deleteProperty(chrome.runtime, 'restartAfterDelay');
+
+    const nowDate = Date.now();
+    const oneHour = 60 * 60 * 1000;
+    const restartDate = new Date(nowDate + oneHour);
+    const hh = `${restartDate.getHours()}`.padStart(2, '0');
+    const mm = `${restartDate.getMinutes()}`.padStart(2, '0');
+    const content = {display: {restartEnabled: true, restartTime: `${hh}:${mm}`}};
+
+    rebootScheduler.scheduleRebootFromViewerContents(content, nowDate);
+
+    sinon.assert.calledWith(chrome.alarms.create, 'restart', {when: restartDate});
+    chrome.runtime.restartAfterDelay = originalRestartAfterDelay;
+  });
+
 });


### PR DESCRIPTION
   - Schedule an alarm that calls chrome.runtime.restart when chrome.runtime.restartAfterDelay is not available