### PR TITLE
Unwatch expired files

### DIFF
--- a/src/storage/database/lokijs/database.js
+++ b/src/storage/database/lokijs/database.js
@@ -1,4 +1,4 @@
-const COLLECTIONS = ["metadata", "runtime_info", "watchlist"];
+const COLLECTIONS = ["metadata", "runtime_info", "watchlist", "expired"];
 
 const loki = require("lokijs");
 const LokiIndexedAdapter = require("lokijs/src/loki-indexed-adapter");

--- a/src/storage/storage.js
+++ b/src/storage/storage.js
@@ -12,6 +12,7 @@ function init() {
     .then(() => expiration.cleanExpired())
     .then(() => {
       messaging.init();
+      expiration.requestUnwatchExpired();
       watchlist.requestWatchlistCompare();
       downloadQueue.checkStaleFiles();
       expiration.scheduleIncreaseSequence();

--- a/test/unit/storage/storage.js
+++ b/test/unit/storage/storage.js
@@ -23,6 +23,7 @@ describe('Storage', () => {
     sandbox.stub(fileSystem, 'clearLeastRecentlyUsedFiles').resolves();
     sandbox.stub(expiration, 'cleanExpired').resolves();
     sandbox.stub(expiration, 'scheduleIncreaseSequence').resolves();
+    sandbox.stub(expiration, 'requestUnwatchExpired').resolves();
   });
 
   it('should initialize storage messaging', () => {


### PR DESCRIPTION
This is part of the fix for defect https://github.com/Rise-Vision/rise-launcher-electron/issues/757

As MS doesn't remove deleted entries on DELETE anymore, local storage should send a unwatch message to tell MS to remove files from watchlist and fileMetadata.