### PR TITLE
Handle default content json file with no schedule

### DIFF
--- a/src/content-comparison.js
+++ b/src/content-comparison.js
@@ -1,12 +1,17 @@
+const defaultPresentationId = "2b95b77e-839c-4674-b020-e2198df49061";
+
 module.exports = {
   compareContentData(newData) {
     if (!validateData(newData)) {return Promise.reject(Error('invalid data'));}
 
     const newPresDates = getPresDatesFromContent(newData);
 
-    const newSchedDate = {
+    const newSchedDate = newData.content.schedule ? {
       "id": newData.content.schedule.id,
       "changeDate": newData.content.schedule.changeDate
+    } : {
+      "id": "no-schedule",
+      "changeDate": "no-schedule"
     };
 
     return new Promise(res=>{
@@ -31,10 +36,17 @@ module.exports = {
 function validateData(newData) {
   if (!newData) {return false}
   if (!newData.content) {return false}
-  if (!newData.content.schedule) {return false}
   if (!newData.content.presentations) {return false}
+  if (!newData.content.schedule &&
+  !isDefaultContentJson(newData.content.presentations)) {return false}
 
   return true;
+}
+
+function isDefaultContentJson(presentations) {
+  return Array.isArray(presentations) &&
+  presentations.length === 1 &&
+  presentations[0].id === defaultPresentationId;
 }
 
 function getPresDatesFromContent({content}) {

--- a/test/unit/content-comparison.js
+++ b/test/unit/content-comparison.js
@@ -234,6 +234,18 @@ describe('Content Comparison', () => {
       }))
     });
 
+    it('should pass without a schedule if default content.json', () => {
+      assert.doesNotReject(contentComparison.compareContentData({
+        content: {
+          presentations: [
+            {
+              id: "2b95b77e-839c-4674-b020-e2198df49061"
+            }
+          ]
+        }
+      }))
+    });
+
     it('passing', () => {
       assert.doesNotReject(contentComparison.compareContentData({
         content: {
@@ -243,5 +255,4 @@ describe('Content Comparison', () => {
       }))
     });
   });
-
 });


### PR DESCRIPTION
Content comparison should expect content with no schedule object for
cases when the display is using the default schedule.