### PR TITLE
Improve viewer injection

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -19,7 +19,7 @@ function setUpMessaging() {
   webview.addEventListener('loadstart', (evt) => {
     if (!evt.isTopLevel) {return;}
     if (!evt.url.match(/http[s]?:\/\/viewer(?:-test)?.risevision.com/)) {return;}
-    webview.executeScript({code: viewerInjector.generateMessagingSetupFunction()}, ()=>{
+    webview.executeScript({code: viewerInjector.generateMessagingSetupFunction(), runAt: 'document_end'}, ()=>{
       viewerMessaging.send({from: 'player', topic: 'latch-app-window'});
     });
   });


### PR DESCRIPTION
   - Add undocumented runAt option set to 'document_end' to `webview.executeScript` call hoping that it will avoid the timing issue where viewer executes its code before injection happens

I found this option mentioned in [this Stack Overflow answer](https://stackoverflow.com/a/26833386) and tried it first with 'document_start' but it didn't work because document.head was not ready yet so we can't inject the script element.

According to the [documentation](https://developer.chrome.com/extensions/content_scripts#run_time) and [Chrome's source code](https://cs.chromium.org/chromium/src/extensions/common/user_script.h?rcl=902482f96ca679f42c17c4abb1bedea401322f05&l=63), the default execution time is 'document_idle' which can happen later than content loads leading to the timing issue with viewer. This PR changes it to 'document_end' which is essentially the same as 'DOMContentLoad' so it should prevent the timing issue to occur as viewer [inits on this same event but after a delay](https://github.com/Rise-Vision/viewer/blob/master/src/main/webapp/Viewer.html#L409).