### PR TITLE
Use documentElement and textContent

### DIFF
--- a/src/viewer-injector.js
+++ b/src/viewer-injector.js
@@ -79,8 +79,8 @@ function generateScriptText(fn) {
 
   const scriptText = `(function() {
       var script = document.createElement("script");
-      script.innerHTML = "(function() { (${fnText})(); })()"
-      document.head.appendChild(script);
+      script.textContent = "(function() { (${fnText})(); })()";
+      (document.head || document.documentElement).appendChild(script);
       })()`;
   return scriptText;
 }


### PR DESCRIPTION
In some cases head is not available so documentElement (<html>) is used
for the script tag as a fallback.

TextContent is used since we're not providing HTML for the script
contents.