### PR TITLE
Don't close reg window before setting webview src

### DIFF
--- a/src/window-manager.js
+++ b/src/window-manager.js
@@ -51,8 +51,8 @@ function createWebViewWindow(file, url, options = {}) {
           console.error(err);
         });
         webview.src = url;
+        resolve(appWin);
       });
-      resolve(appWin);
     });
   });
 }

--- a/test/unit/window-manager.js
+++ b/test/unit/window-manager.js
@@ -46,8 +46,18 @@ describe('Window Manager', () => {
   });
 
   it('should close previous window when viewer is launched', () => {
-    const viewerWindow = {onClosed: {addListener() {}}, contentWindow: {addEventListener() {}}};
+    const viewerWindow = {
+      onClosed: {addListener() {}},
+      contentWindow: {
+        addEventListener() {},
+        document: {
+          querySelector() {}
+        }
+      }
+    }
     sandbox.stub(viewerWindow.onClosed, 'addListener').yields([]);
+    sandbox.stub(viewerWindow.contentWindow, 'addEventListener').yields([]);
+    sandbox.stub(viewerWindow.contentWindow.document, 'querySelector').returns({addEventListener() {}});
     chrome.app.window.create.yields(viewerWindow);
 
     const previousWindow = {close: sinon.spy()};
@@ -70,8 +80,18 @@ describe('Window Manager', () => {
     const previousWindow = {close: sinon.spy()};
     chrome.app.window.current.returns(previousWindow);
 
-    const viewerWindow = {onClosed: {addListener() {}}, contentWindow: {addEventListener() {}}};
+    const viewerWindow = {
+      onClosed: {addListener() {}},
+      contentWindow: {
+        addEventListener() {},
+        document: {
+          querySelector() {}
+        }
+      }
+    };
     sandbox.stub(viewerWindow.onClosed, 'addListener').yields([]);
+    sandbox.stub(viewerWindow.contentWindow, 'addEventListener').yields([]);
+    sandbox.stub(viewerWindow.contentWindow.document, 'querySelector').returns({addEventListener() {}});
     chrome.app.window.create.yields(viewerWindow);
 
     const displayId = 'displayId';


### PR DESCRIPTION
In chrome os 71 there is a slight difference in ordering of async
operations.

The createWebviewWindow promise resolves before the viewer window
DOMContentLoaded event. This results in the registration window being
closed due to the previousWindow.close() call and so the webview.src is
never set and viewer.risevision.com/Viewer.html is never loaded.

That in turn results in the script injection not firing because it is
waiting for loadCommit event.

@andrecardoso can you test this on a chrome 70 device? I tested it on my dev linux machine on chrome 70, and my chrome bit on chrome 71. I'm going to keep my device on 71.