### PR TITLE
Do not override error message from MS

### DIFF
--- a/src/storage/messaging/watch/watch.js
+++ b/src/storage/messaging/watch/watch.js
@@ -107,10 +107,10 @@ module.exports = {
       .then(() => db.fileMetadata.updateWatchSequence(filePath));
   },
   msResult(message) {
-    const {filePath, error, folderData, watchlistLastChanged} = message;
+    const {filePath, errorCode, errorMsg, folderData, watchlistLastChanged} = message;
 
-    if (error) {
-      return localMessaging.sendFileUpdate({filePath, status: "NOEXIST"});
+    if (errorCode || errorMsg) {
+      return localMessaging.sendFileUpdate({filePath, status: errorMsg || errorCode});
     }
 
     const action = folderData ? handleFolderWatchResult : handleFileWatchResult;

--- a/test/unit/storage/messaging/watch/watch.js
+++ b/test/unit/storage/messaging/watch/watch.js
@@ -149,7 +149,8 @@ describe("Storage Watch", () => {
     it("should broadcast FILE-UPDATE with NOEXIST status when error providing from MS", () => {
       const msMessage = {
         filePath: "risemedialibrary-7d948ac7-decc-4ed3-aa9c-9ba43bda91dc/new_photos/screenshot.jpg",
-        error: "NOEXIST"
+        error: "NOEXIST",
+        errorMsg: "NOEXIST"
       };
       return watch.msResult(msMessage).then(() => {
         sinon.assert.calledWith(localMessaging.sendFileUpdate, {filePath: msMessage.filePath, status: "NOEXIST"});


### PR DESCRIPTION
This was merged in local-storage-module here https://github.com/Rise-Vision/local-storage-module/pull/86 but it was missing on Chrome OS. It is required to fix https://github.com/Rise-Vision/rise-launcher-electron/issues/773