### PR TITLE
Resubmit WATCH for empty folders

### DIFF
--- a/src/storage/messaging/watch/watch.js
+++ b/src/storage/messaging/watch/watch.js
@@ -65,11 +65,19 @@ function processFolderWatch(message, existingMetadata) {
   const folderPath = message.filePath;
   if (existingMetadata) {
     const folderFiles = db.fileMetadata.getFolderFiles(folderPath);
-    logger.log(`storage - processing watch for existing folder ${folderPath}, ${JSON.stringify(folderFiles)}`);
-    const promises = folderFiles.map(fileMetadata => processFileWatch({filePath: fileMetadata.filePath, topic: 'watch'}, fileMetadata));
-    return Promise.all(promises);
+
+    if (folderFiles.length > 0) {
+      logger.log(`storage - processing watch for existing folder ${folderPath}, ${JSON.stringify(folderFiles)}`);
+      const promises = folderFiles.map(fileMetadata => processFileWatch({
+        filePath: fileMetadata.filePath,
+        topic: 'watch'
+      }, fileMetadata));
+
+      return Promise.all(promises);
+    }
   }
 
+  logger.log(`storage - requesting MS update for folder ${folderPath}`);
   return requestMSUpdate(message, {filePath: folderPath, version: "0"});
 }
 

--- a/src/storage/messaging/watch/watchlist.js
+++ b/src/storage/messaging/watch/watchlist.js
@@ -9,7 +9,7 @@ function requestWatchlistCompare() {
   const lastChanged = db.watchlist.lastChanged();
   const msMessage = {topic: "WATCHLIST-COMPARE", lastChanged};
 
-  logger.log(`storage - Sending WATCHLIST-COMPARE against ${lastChanged}`);
+  logger.log(`storage - sending WATCHLIST-COMPARE`, {lastChanged});
   messagingServiceClient.send(msMessage);
 }
 
@@ -47,7 +47,7 @@ function markMissingFilesAsUnknown(remoteWatchlist) {
 
 function refresh(watchlist, lastChanged) {
   const filePaths = Object.keys(watchlist);
-  logger.log(`storage - Received WATCHLIST-RESULT for ${lastChanged} with count: ${filePaths.length}`);
+  logger.log(`storage - received WATCHLIST-RESULT`, {lastChanged, filePaths});
 
   if (filePaths.length === 0) {
     return Promise.resolve();

--- a/src/storage/messaging/watch/watchlist.js
+++ b/src/storage/messaging/watch/watchlist.js
@@ -1,4 +1,5 @@
 const messagingServiceClient = require('../../../messaging/messaging-service-client');
+const logger = require('../../../logging/logger');
 const db = require("../../database/api");
 const deleteFile = require("../delete/delete");
 const update = require("../update/update");
@@ -8,6 +9,7 @@ function requestWatchlistCompare() {
   const lastChanged = db.watchlist.lastChanged();
   const msMessage = {topic: "WATCHLIST-COMPARE", lastChanged};
 
+  logger.log(`storage - Sending WATCHLIST-COMPARE against ${lastChanged}`);
   messagingServiceClient.send(msMessage);
 }
 
@@ -45,6 +47,7 @@ function markMissingFilesAsUnknown(remoteWatchlist) {
 
 function refresh(watchlist, lastChanged) {
   const filePaths = Object.keys(watchlist);
+  logger.log(`storage - Received WATCHLIST-RESULT for ${lastChanged} with count: ${filePaths.length}`);
 
   if (filePaths.length === 0) {
     return Promise.resolve();

--- a/test/unit/storage/messaging/watch/watch.js
+++ b/test/unit/storage/messaging/watch/watch.js
@@ -107,12 +107,21 @@ describe("Storage Watch", () => {
       });
     });
 
-    it("should not request MS updates when folder has already been watched", () => {
+    it("should not request MS updates when folder is not empty", () => {
+      sandbox.stub(db.fileMetadata, 'get').returns({filePath: folderMessage.filePath, status: 'STALE', version: '1'});
+      sandbox.stub(db.fileMetadata, 'getFolderFiles').returns([{filePath: "test-filep-path", status: "STALE"}]);
+
+      return watch.process(folderMessage).then(() => {
+        sinon.assert.notCalled(messagingServiceClient.send);
+      });
+    });
+
+    it("should request MS updates when folder is empty", () => {
       sandbox.stub(db.fileMetadata, 'get').returns({filePath: folderMessage.filePath, status: 'CURRENT', version: '1'});
       sandbox.stub(db.fileMetadata, 'getFolderFiles').returns([]);
 
       return watch.process(folderMessage).then(() => {
-        sinon.assert.notCalled(messagingServiceClient.send);
+        sinon.assert.calledOnce(messagingServiceClient.send);
       });
     });
 

--- a/test/unit/storage/messaging/watch/watchlist.js
+++ b/test/unit/storage/messaging/watch/watchlist.js
@@ -7,17 +7,20 @@ const db = require('../../../../../src/storage/database/api');
 const watch = require('../../../../../src/storage/messaging/watch/watch');
 const watchlist = require('../../../../../src/storage/messaging/watch/watchlist');
 
+const logger = require('../../../../../src/logging/logger');
 const sandbox = sinon.createSandbox();
 
 describe('Storage Watchlist', () => {
 
   afterEach(() => sandbox.restore());
+  beforeEach(()=> sandbox.stub(logger, 'log'));
 
   describe('WATCHLIST-COMPARE', () => {
     beforeEach(() => sandbox.stub(messagingServiceClient, 'send'));
 
     it('requests WATCHLIST-COMPARE', ()=> {
       sandbox.stub(db.watchlist, 'lastChanged').returns(123456);
+
 
       watchlist.requestWatchlistCompare();
 


### PR DESCRIPTION
If a folder watch is submitted against a folder that doesn't exist on
GCS, MS doesn't record it in the watchlist as the error is returned
early.

But local-storage will record the folder in the file metadata.

This change ensures that any missing folders are resubmitted by
local-storage so that a new GCS check is triggered.