### PR TITLE
Configure webview messaging on load url

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -122,6 +122,7 @@ function loadViewerUrl() {
 function loadUrl(url) {
   const webview = document.querySelector('webview');
   webview.src = url;
+  viewerMessaging.configure(webview);
 }
 
 function isViewerLoaded() {

--- a/src/messaging/viewer-messaging.js
+++ b/src/messaging/viewer-messaging.js
@@ -13,17 +13,15 @@ const dataHandlerRegisteredObserver = {
 const messageHandlers = {};
 let messageSender = null;
 
-function createMessageSender(webview) {
+function createMessageSender(webview, targetOrigin = webview.src) {
   return {
     sendMessage(message) {
-      webview.contentWindow.postMessage(message, webview.src);
+      webview.contentWindow.postMessage(message, targetOrigin);
     }
   }
 }
 
-function init(webview) {
-  messageSender = createMessageSender(webview);
-
+function init() {
   dataHandlerRegisteredObserver.init();
 
   on('data-handler-registered', () => {
@@ -103,6 +101,10 @@ function reset() {
   dataHandlerRegisteredObserver.messageReceived = false;
 }
 
+function configure(webview) {
+  messageSender = createMessageSender(webview);
+}
+
 module.exports = {
   init,
   on,
@@ -110,5 +112,6 @@ module.exports = {
   removeAllListeners,
   send,
   viewerCanReceiveContent,
-  reset
+  reset,
+  configure
 }

--- a/test/unit/messaging/viewer-messaging.js
+++ b/test/unit/messaging/viewer-messaging.js
@@ -19,7 +19,8 @@ describe('Viewer Messaging', () => {
 
   beforeEach(() => {
     sandbox.stub(window, 'addEventListener').callsFake((event, listener) => onMessageEvent = listener);
-    viewerMessaging.init(webview);
+    viewerMessaging.init();
+    viewerMessaging.configure(webview);
   })
 
   it('should indicate viewer can receive content when it receives data-handler-registered', () => {


### PR DESCRIPTION
  - Webview messaging requires the targe origin to be set as the loaded URL for security reasons. We were setting it only when init was called because the URL didn't change. With no viewer mode, we need to configure messaging everytime we load a new URL