### PR TITLE
Set stale when MS provides token

### DIFF
--- a/src/storage/messaging/watch/watch.js
+++ b/src/storage/messaging/watch/watch.js
@@ -29,9 +29,7 @@ function handleFileWatchResult(message) {
 
   logger.log(`storage - received version ${version} for ${filePath}`);
 
-  const status = token && db.fileMetadata.isVersionMismatch(filePath, version) ?
-    'STALE' :
-    'CURRENT';
+  const status = token ? 'STALE' : 'CURRENT';
 
   return update.updateWatchlistAndMetadata({filePath, version, status, token})
   .then(() => sendFileUpdate({filePath, status, version}))

--- a/test/unit/storage/messaging/watch/watch.js
+++ b/test/unit/storage/messaging/watch/watch.js
@@ -179,32 +179,15 @@ describe("Storage Watch", () => {
       });
     });
 
-    it("should broadcast FILE-UPDATE with STALE when token is provided and version is mismatched", () => {
+    it("should broadcast FILE-UPDATE with STALE when token is provided", () => {
       const msMessage = {
         filePath: "risemedialibrary-7d948ac7-decc-4ed3-aa9c-9ba43bda91dc/new_photos/screenshot.jpg",
         version: "123",
         token: {}
       };
-
-      sandbox.stub(db.fileMetadata, 'isVersionMismatch').returns(true);
 
       return watch.msResult(msMessage).then(() => {
         sinon.assert.calledWith(localMessaging.sendFileUpdate, {filePath: msMessage.filePath, status: "STALE", version: msMessage.version});
-      });
-    });
-
-    it("should broadcast FILE-UPDATE with CURRENT when token is provided and version is matched", () => {
-      const msMessage = {
-        filePath: "risemedialibrary-7d948ac7-decc-4ed3-aa9c-9ba43bda91dc/new_photos/screenshot.jpg",
-        version: "123",
-        token: {}
-      };
-
-      sandbox.stub(db.fileMetadata, 'isVersionMismatch').returns(false);
-      sandbox.stub(fileSystem, 'readCachedFile').resolves();
-
-      return watch.msResult(msMessage).then(() => {
-        sinon.assert.calledWithMatch(localMessaging.sendFileUpdate, {filePath: msMessage.filePath, status: "CURRENT", version: msMessage.version});
       });
     });
 


### PR DESCRIPTION
The second check for current version mismatch doesn't work in cases
where a watch is submitted for a file and then another watch is
submitted before the first watch has resulted in a completed download.

The first will update the version, and then the second will set
CURRENT even though the download isn't yet complete.