### PR TITLE
Remove restriction to RiseStorage URLs for no-viewer

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -132,7 +132,7 @@ function isViewerLoaded() {
 }
 
 function loadContent(contentData) {
-  if (scheduleParser.hasOnlyRiseStorageURLItems()) {
+  if (scheduleParser.hasOnlyURLItems()) {
     setupClientInfoLogNoViewer();
     return Promise.resolve(noViewerSchedulePlayer.start());
   }

--- a/src/scheduling/schedule-parser.js
+++ b/src/scheduling/schedule-parser.js
@@ -22,16 +22,13 @@ const DAY_IN_MILLIS = 1000 * 60 * 60 * 24;
 
 module.exports = {
   scheduledToPlay,
-  hasOnlyRiseStorageURLItems(data = scheduleContent) {
+  hasOnlyURLItems(data = scheduleContent) {
     if (!module.exports.validateContent()) {return false;}
-
-    const expectedURLStart = "https://storage.googleapis.com/risemedialibrary";
 
     return data.content.schedule.items.every(item=>{
       if (item.type !== "url") {return false;}
       if (!item.objectReference) {return false;}
       if (typeof item.objectReference !== "string") {return false;}
-      if (!item.objectReference.startsWith(expectedURLStart)) {return false;}
 
       return true;
     });


### PR DESCRIPTION
Initially no-viewer mode was limited to Rise Storage urls based on a
specific target url. We need to enable more urls for widget staging
as well as other Rise Storage origins like commondatastore.googleapis.

Rather than a specific whitelist, we enable no-viewer for *any* urls.
There's no reason to load urls in Viewer.