### PR TITLE
Add description field to manifest.json

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -1,6 +1,7 @@
 {
     "manifest_version": 2,
     "name": "Rise Player",
+    "description": "Rise Player",
     "version": "0.0.0.0",
     "permissions": [
       "<all_urls>",


### PR DESCRIPTION
This is a test to help fixing the duplicate description that appears on Chrome Web Store