### PR TITLE
Fix logging entries with the same timestamp

### DIFF
--- a/src/logging/bq-client.js
+++ b/src/logging/bq-client.js
@@ -58,7 +58,10 @@ function insertMultiple(entries, dataset, table) {
   return refreshToken(nowDate).then(() => {
     const insertData = config.insertSchema;
     insertData.rows = entries.map(entry => {
-      return {json: entry, insertId: entry.ts};
+      return {
+        json: entry,
+        insertId: Math.random().toString(36).substr(2).toUpperCase() // eslint-disable-line no-magic-numbers
+      };
     });
 
     const options = {


### PR DESCRIPTION
Inserting multiple entries with the same timestamp was failing, only one entry would be recorded.
Therefore, component uptime was being logged for only one of the components of a template.
Updated to follow electron implementation: https://github.com/Rise-Vision/rise-common-electron/blob/master/bq-client.js#L50.

@andrecardoso @alex-deaconu Please review. Thanks