### PR TITLE
Uses HTTPS for loading HTML Templates

### DIFF
--- a/src/html-template-url-parser.js
+++ b/src/html-template-url-parser.js
@@ -7,7 +7,7 @@ module.exports = {
 
     const restructuredData = JSON.parse(JSON.stringify(contentData));
 
-    const HTMLTemplateURL = "http://widgets.risevision.com/STAGE/templates/PCODE/src/template.html?presentationId=PID";
+    const HTMLTemplateURL = "https://widgets.risevision.com/STAGE/templates/PCODE/src/template.html?presentationId=PID";
     const isBeta = systemInfo.isBeta();
 
     restructuredData.content.schedule.items

--- a/test/unit/content-loader.js
+++ b/test/unit/content-loader.js
@@ -92,7 +92,7 @@ describe('Content Loader', () => {
     chrome.storage.local.get.yields({displayId: 'displayId'});
     const testObjRef = "test-obj-ref";
     const testPCode = "test-p-code";
-    const computedTemplateURL = `http://widgets.risevision.com/stable/templates/${testPCode}/src/template.html?presentationId=${testObjRef}`;
+    const computedTemplateURL = `https://widgets.risevision.com/stable/templates/${testPCode}/src/template.html?presentationId=${testObjRef}`;
 
     const contentData = {
       content: {


### PR DESCRIPTION
Uses HTTPS for loading HTML Templates to allow Service Workers and Cache API to work.

@alex-deaconu @andrecardoso Please review. Thanks!