### PR TITLE
Fix delay when waiting for viewer

### DIFF
--- a/src/network-checks/index.js
+++ b/src/network-checks/index.js
@@ -62,7 +62,7 @@ module.exports = {
     isComplete = false;
     module.exports.checkSites();
   },
-  waitForViewer(attempt = 0, timeout = 1000) { // eslint-disable-line no-magic-numbers
+  waitForViewer(attempt = 1, timeout = 1000) { // eslint-disable-line no-magic-numbers
     return fetch("http://viewer.risevision.com")
     .then(resp => resp.ok ? resp : Promise.reject(Error(`${resp.statusText}`)))
     .catch(error => {

--- a/test/unit/network-checks/index.js
+++ b/test/unit/network-checks/index.js
@@ -1,0 +1,50 @@
+/* eslint-disable func-style, no-magic-numbers */
+const assert = require('assert');
+const sinon = require('sinon');
+
+const networkChecks = require('../../../src/network-checks');
+const logger = require('../../../src/logging/logger');
+
+const sandbox = sinon.createSandbox();
+const fetch = sandbox.stub();
+
+describe('Network Checks', ()=>{
+
+  before(() => {
+    global.fetch = fetch;
+  });
+
+  after(() => Reflect.deleteProperty(global, 'fetch'));
+
+  beforeEach(() => fetch.resetBehavior());
+
+  beforeEach(() => {
+    sandbox.stub(logger, 'log');
+    sandbox.stub(logger, 'error');
+    sandbox.stub(global, "setTimeout");
+  });
+
+  afterEach(() => sandbox.restore());
+
+  it('wait for viewer resolves when fetch works', ()=>{
+
+    fetch.resolves({ok: true});
+
+    return networkChecks.waitForViewer().then(() => {
+      assert.equal(logger.error.notCalled, true);
+    })
+  });
+
+  it('wait for viewer resolves when fetch works after delay', ()=>{
+    setTimeout.yields();
+    fetch.onFirstCall().resolves({ok: false})
+      .onSecondCall().resolves({ok: false})
+      .onThirdCall().resolves({ok: true});
+
+    return networkChecks.waitForViewer().then(() => {
+      assert.equal(setTimeout.firstCall.args[1], 1000);
+      assert.equal(logger.error.callCount, 1);
+    })
+  });
+
+});


### PR DESCRIPTION
## Description
Fix delay when player is waiting for viewer when started offline

## Motivation and Context
Player is not delaying when retrying check for viewer when started offline. 

## How Has This Been Tested?
Unit and manual tests

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

