### PR TITLE
Fix for issue 668

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -178,13 +178,13 @@ function init() {
   .then(() => {
     setUpMessaging()
       .then(storage.init)
+      .then(fetchContent)
       .then(licensing.init)
       .then(debugDataRequest.init)
       .catch(error => logger.error('player - error when initilizing modules', error));
     fileServer.init();
     uptime.init();
     contentUptime.init();
-    fetchContent();
   });
 
   const webview = document.querySelector('webview');

--- a/src/messaging/viewer-messaging.js
+++ b/src/messaging/viewer-messaging.js
@@ -1,3 +1,5 @@
+const scheduleParser = require('../scheduling/schedule-parser');
+
 const dataHandlerRegisteredObserver = {
   init() {
     this.messageReceived = false;
@@ -89,6 +91,10 @@ function handleMessage(data) {
 
 function viewerCanReceiveContent() {
   return new Promise(resolve => {
+    if (scheduleParser.hasOnlyNoViewerURLItems()) {
+      return resolve();
+    }
+
     dataHandlerRegisteredObserver.resolvers.push(resolve);
     if (dataHandlerRegisteredObserver.messageReceived) {
       dataHandlerRegisteredObserver.resolve();

--- a/test/unit/messaging/viewer-messaging.js
+++ b/test/unit/messaging/viewer-messaging.js
@@ -2,6 +2,7 @@ const sinon = require('sinon');
 const chrome = require('sinon-chrome/apps');
 
 const viewerMessaging = require('../../../src/messaging/viewer-messaging');
+const scheduleParser = require('../../../src/scheduling/schedule-parser');
 
 const sandbox = sinon.createSandbox();
 const window = {addEventListener() {}};
@@ -47,6 +48,14 @@ describe('Viewer Messaging', () => {
     onMessageEvent({data, preventDefault() {}});
 
     return Promise.all(promises);
+  });
+
+  it('should not wait for message from Viewer when running in no-Viewer mode', () => {
+    sandbox.stub(scheduleParser, 'hasOnlyNoViewerURLItems').returns(true);
+
+    const promise = viewerMessaging.viewerCanReceiveContent();
+
+    return promise;
   });
 
   it('should respond to client list request message', () => {


### PR DESCRIPTION
## Description
Fix for https://github.com/Rise-Vision/html-template-library/issues/668.

## Motivation and Context
The main reason why the Google Slides template was showing black screen is that in some case `common-template` requested attribute data before storage module loaded, so it was a timing issue. This problem is resolved by ensuring that `fetchContent()` is called after `storage.init()`.

This PR also fixes another problem with Player when it starts in no-Viewer mode.  In that case `viewerCanReceiveContent()` blocked Player's initialization sequence. The caused the following problems: 
1) Player never called `submitWatchForProductAuthChanges` i.e. it didn't register watch for product authorization changes.
2) Player had errors from which it could not recover during scheduled restart (see "USE CASE 1" on [this card](https://trello.com/c/ADkEiWfX/291-2-668-google-slides-template-showing-black-screen-on-certain-chromeos-displays)). 

## How Has This Been Tested?
Tested manually,

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
