### PR TITLE
Handle empty watchlist

### DIFF
--- a/src/storage/messaging/watch/watchlist.js
+++ b/src/storage/messaging/watch/watchlist.js
@@ -61,7 +61,7 @@ function refresh(watchlist, lastChanged) {
   const filePaths = Object.keys(watchlist);
   logger.log(`storage - received WATCHLIST-RESULT`, {lastChanged, filePaths});
 
-  if (filePaths.length === 0) {
+  if (filePaths.length === 0 && lastChanged !== "0") {
     return Promise.resolve();
   }
 


### PR DESCRIPTION
## Description
Mark local files and folders when server watchlist is empty and last changed is 0

## Motivation and Context
This is to force refreshing local files when messaging service watchlist is empty when data is lost on the server causing issues such as https://github.com/Rise-Vision/rise-launcher-electron/issues/832

## How Has This Been Tested?
Tested locally using stage environment by deleting the watchlist and last changed manually from redis

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
