### PR TITLE
Stage/fix issue 805

### DIFF
--- a/src/scheduling/schedule-parser.js
+++ b/src/scheduling/schedule-parser.js
@@ -25,6 +25,10 @@ module.exports = {
   hasOnlyNoViewerURLItems(data = scheduleContent) {
     if (!module.exports.validateContent(data)) {return false;}
 
+    if (data.content.schedule.items.length > 1) {
+      return false;
+    }
+
     const noViewerURLs = /(http(s)?:\/\/)?storage\.googleapis\.com\/risemedialibrary.+|(http(s)?:\/\/)?widgets\.risevision\.com\/.+/;
 
     return data.content.schedule.items.every(item=>{

--- a/test/unit/content-loader.js
+++ b/test/unit/content-loader.js
@@ -111,11 +111,6 @@ describe('Content Loader', () => {
               "type": "presentation",
               "presentationType": "HTML Template",
               "objectReference": testObjRef
-            },
-            {
-              "type": "presentation",
-              "presentationType": "HTML Template",
-              "objectReference": "other-obj-ref"
             }
           ]
         }
@@ -127,7 +122,6 @@ describe('Content Loader', () => {
       const items = data.content.schedule.items;
       assert.equal(items[0].type, "url");
       assert.equal(items[0].objectReference, computedTemplateURL);
-      assert.equal(items[1].type, "url");
     });
   });
 
@@ -187,10 +181,6 @@ describe('Content Loader', () => {
           {
             "id": testObjRef,
             "productCode": testPCode
-          },
-          {
-            "id": "other-obj-ref",
-            "productCode": "other-p-code"
           }
         ],
         schedule: {
@@ -199,11 +189,6 @@ describe('Content Loader', () => {
               "type": "presentation",
               "presentationType": "HTML Template",
               "objectReference": testObjRef
-            },
-            {
-              "type": "presentation",
-              "presentationType": "HTML Template",
-              "objectReference": "other-obj-ref"
             }
           ]
         }

--- a/test/unit/scheduling/schedule-parser.js
+++ b/test/unit/scheduling/schedule-parser.js
@@ -280,4 +280,31 @@ describe("Schedule Parser", () => {
     urlItem.objectReference = "https://widgets.risevision.com/staging/pages/2018.12.28.14.00/src/rise-data-image.html";
     assert.equal(scheduleParser.hasOnlyNoViewerURLItems(data), false);
   });
+
+  it("should return false when multiple items supports no viewer mode", () => {
+    const urlItem = {
+      type: "url",
+      objectReference: "http://storage.googleapis.com/risemedialibrary-7d948ac7-decc-4ed3-aa9c-9ba43bda91dc/pwa-examples/js13kpwa/index4.html"
+    };
+
+    const templateItem = {
+      name: "Copy of Single Agriculture",
+      type: "presentation",
+      presentationType: "HTML Template",
+      objectReference: "8c5059bc-f6f1-4c2b-b886-eccc1d37ed74",
+      duration: 30,
+      timeDefined: false
+    };
+
+    const data = {
+      content: {
+        schedule: {
+          items: [urlItem, templateItem]
+        }
+      }
+    };
+
+    assert.equal(scheduleParser.hasOnlyNoViewerURLItems(data), false);
+
+  });
 });


### PR DESCRIPTION
## Description
Fix for https://github.com/Rise-Vision/html-template-library/issues/805

## Motivation and Context
Player does not keep templates in memory. Template resource files are loaded every time when the template becomes visible. This causes the the default values to be shown while template is loading. 

This is fixed the [same way as Electron Player](https://github.com/Rise-Vision/rise-player-electron/blob/master/src/main/scheduling/schedule-parser.js#L29) - if a schedule has more than one item, then player runs in the "Viewer" mode. That way Templates are not reloaded on every show.

## How Has This Been Tested?
Tested manually. Unit tests are included.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
