### PR TITLE
Update to load Viewer from widgets.risevision.com

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -20,7 +20,7 @@ const noViewerSchedulePlayer = require('./scheduling/schedule-player');
 const contentWatchdog = require('./content-watchdog');
 const whiteScreenAnalyser = require('./white-screen-analyser');
 
-const VIEWER_URL = "viewer.risevision.com/Viewer.html";
+const VIEWER_URL = "widgets.risevision.com/viewer/Viewer.html";
 
 function setUpMessaging() {
   const webview = document.querySelector('webview');

--- a/src/network-checks/index.js
+++ b/src/network-checks/index.js
@@ -5,7 +5,7 @@ const TIMEOUT_MILLIS = 60000;
 const TIMEOUT_ERROR = Error('network-check-timeout');
 const NOT_ONLINE_ERROR = Error('network-not-online');
 const siteList = [
-  "http://viewer.risevision.com",
+  "http://widgets.risevision.com/viewer/Viewer.html",
   "http://widgets.risevision.com/widget-image/0.1.1/dist/widget.html",
   "http://s3.amazonaws.com/widget-video-rv/1.1.0/dist/widget.html",
   "https://services.risevision.com/healthz",
@@ -63,7 +63,7 @@ module.exports = {
     module.exports.checkSites();
   },
   waitForViewer(attempt = 1, timeout = 1000) { // eslint-disable-line no-magic-numbers
-    return fetch("http://viewer.risevision.com")
+    return fetch("http://widgets.risevision.com/viewer/Viewer.html")
     .then(resp => resp.ok ? resp : Promise.reject(Error(`${resp.statusText}`)))
     .catch(error => {
       logger.error('waiting for viewer', error);

--- a/src/uptime/network-investigation.js
+++ b/src/uptime/network-investigation.js
@@ -2,7 +2,7 @@ const logger = require('../logging/logger');
 
 const siteList = [
   "https://services.risevision.com/healthz",
-  "https://viewer.risevision.com",
+  "https://widgets.risevision.com/viewer/Viewer.html",
   "https://storage-dot-rvaserver2.appspot.com",
   "https://store.risevision.com",
   "https://s3.amazonaws.com/widget-video-rv/1.1.0/dist/widget.html",

--- a/test/unit/content.js
+++ b/test/unit/content.js
@@ -22,25 +22,25 @@ describe('Content', () => {
     sandbox.stub(scheduleParser, 'hasOnlyHtmlTemplates').returns(true);
 
     const viewerUrl = content._getViewerUrlForSchedule();
-    assert.equal(viewerUrl, "https://viewer.risevision.com/Viewer.html");
+    assert.equal(viewerUrl, "https://widgets.risevision.com/viewer/Viewer.html");
   });
 
   it('should load Viewer over HTTP when includes non template items', () => {
     sandbox.stub(scheduleParser, 'hasOnlyHtmlTemplates').returns(false);
 
     const viewerUrl = content._getViewerUrlForSchedule();
-    assert.equal(viewerUrl, "http://viewer.risevision.com/Viewer.html");
+    assert.equal(viewerUrl, "http://widgets.risevision.com/viewer/Viewer.html");
   });
 
   it('should return true if http protocol of the currently running viewer matches protocol of the new schedule', () => {
-    global.document.querySelector = () => {return {src: 'https://viewer.risevision.com/Viewer.html'}};
+    global.document.querySelector = () => {return {src: 'https://widgets.risevision.com/viewer/Viewer.html'}};
     sandbox.stub(scheduleParser, 'hasOnlyHtmlTemplates').returns(true);
 
     assert.equal(content._viewerHttpProtocolMatches(), true);
   });
 
   it('should return false if http protocol of the currently running viewer does not match protocol of the new schedule', () => {
-    global.document.querySelector = () => {return {src: 'http://viewer.risevision.com/Viewer.html'}};
+    global.document.querySelector = () => {return {src: 'http://widgets.risevision.com/viewer/Viewer.html'}};
     sandbox.stub(scheduleParser, 'hasOnlyHtmlTemplates').returns(true);
 
     assert.equal(content._viewerHttpProtocolMatches(), false);


### PR DESCRIPTION
## Description
Load Viewer from `https://widgets.risevision.com/viewer/Viewer.html` 

## Motivation and Context
Origin consolidation

## How Has This Been Tested?
Tested locally via installing as unpackaged app extension

Validated viewer correctly loaded from right location and validated content with this schedule https://apps.risevision.com/schedules/details/822cbbd2-ad76-44c1-acc6-cff355e1c133?cid=7fa5ee92-7deb-450b-a8d5-e5ed648c575f which contains 2 random templates and a legacy presentation containing a few different widgets. 

**PENDING**
Test legacy presentation containing gadgets, which is dependent on fixing `makeRequest` when Viewer loaded from widgets.risevision.com. 

## Release Plan:
- Update and deploy Viewer to fix `makeRequest` when loaded from widgets.risevision.com
- Deploy to lesser used version in App Store
- Deploy to widely used version in App Store

#### Release Checklist Items Skipped?
none
