### PR TITLE
Relax max version restriction

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,22 @@ npm run test
 * Edit the files under `src`. Webpack will generate a `*.bundle.js` files into `app`. This directory contains all the files required for the packaged app.
 
 * Load the packaged app directory `app` on `chrome://extensions`
+
+# Version Restrictions
+
+The manifest will restrict chrome updates based on the
+*required_platform_version* field if running as a kiosk app.
+
+This [help page](https://support.google.com/chrome/a/answer/9273974?hl=en)
+describes the functionality.
+
+The
+[buildspecs](https://chromium.googlesource.com/chromiumos/manifest-versions/+/master/paladin/buildspecs/)
+can be used to look up the platform versions for a particular chrome version.
+
+For past and future release dates see the [rollout schedule](https://chromiumdash.appspot.com/schedule).
+
+The [Chrome Releases
+blog](https://chromereleases.googleblog.com/2020/05/stable-channel-update-for-chrome-os.html)
+includes notifications of Chrome OS updates including Chrome version and
+Platform version.

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -57,6 +57,6 @@
     "kiosk_enabled": true,
     "kiosk": {
       "always_update": true,
-      "required_platform_version": "10032.86.0"
+      "required_platform_version": "12871.102.0"
     }
   }


### PR DESCRIPTION
## Description
Relax platform restriction to allow upgrade to version 81.

## Motivation and Context
Requested by Alan.  See https://trello.com/c/Vf08UFUt/6557-chrome-player-allows-chrome-os-to-upgrade-to-chrome-version-81

## How Has This Been Tested?
No code change.
Will confirm upgrade on uptime.

## Release Plan:
- 100%